### PR TITLE
feat: flexible WorkListing + typed header/footer + insights paginator…

### DIFF
--- a/src/components/molecules/WorkCard.astro
+++ b/src/components/molecules/WorkCard.astro
@@ -1,5 +1,17 @@
 ---
-const { href, title, summary, img, alt, chips = [] } = Astro.props;
+import type { ImageMetadata } from 'astro';
+
+type Chip = { label: string; href: string | null };
+interface Props {
+	href: string;
+	title: string;
+	summary: string;
+	img: ImageMetadata;
+	alt: string;
+	chips?: Chip[];
+}
+
+const { href, title, summary, img, alt, chips = [] } = Astro.props as Props;
 ---
 
 <article class="work-card">

--- a/src/components/organisms/ContactForm.astro
+++ b/src/components/organisms/ContactForm.astro
@@ -21,14 +21,14 @@
    - With JS enabled, we AJAX-submit and show inline status (no redirect).
 ====================================================================== */
 
-import Button from "../atoms/Button.astro";
+import Button from '../atoms/Button.astro';
 
 /** Props */
 const {
-	formName = "contact",
-	successText = "Thanks! Your message has been sent.",
-	errorText = "Sorry — something went wrong. Please try again.",
-	class: className = "",
+	formName = 'contact',
+	successText = 'Thanks! Your message has been sent.',
+	errorText = 'Sorry — something went wrong. Please try again.',
+	class: className = '',
 	redirect, // e.g. "/thank-you"
 	recaptcha = false,
 } = Astro.props;
@@ -85,26 +85,27 @@ const action = redirect || undefined; // only set action when you want non-JS re
 	<p class="form-help" data-status role="status" aria-live="polite"></p>
 </form>
 
-<script type="module" define:vars={{ formId, successText, errorText }}>
+<script is:inline type="module" define:vars={{ formId, successText, errorText }}>
+	// @ts-nocheck
 	const form = document.getElementById(formId);
-	const statusEl = form.querySelector("[data-status]");
+	const statusEl = form.querySelector('[data-status]');
 	const submitBtn = form.querySelector('button[type="submit"], input[type="submit"]');
 
 	const setBusy = (busy) => {
-		form.setAttribute("aria-busy", busy ? "true" : "false");
+		form.setAttribute('aria-busy', busy ? 'true' : 'false');
 		if (!submitBtn) return;
 		if (busy) {
-			submitBtn.setAttribute("disabled", "true");
-			submitBtn.classList.add("is-loading"); // uses your .btn.is-loading spinner
+			submitBtn.setAttribute('disabled', 'true');
+			submitBtn.classList.add('is-loading'); // uses your .btn.is-loading spinner
 		} else {
-			submitBtn.removeAttribute("disabled");
-			submitBtn.classList.remove("is-loading");
+			submitBtn.removeAttribute('disabled');
+			submitBtn.classList.remove('is-loading');
 		}
 	};
 
 	const encodeFormData = (fd) => new URLSearchParams(Array.from(fd.entries())).toString();
 
-	form.addEventListener("submit", async (e) => {
+	form.addEventListener('submit', async (e) => {
 		// If JS fails for any reason, let the browser submit normally.
 		try {
 			e.preventDefault();
@@ -112,32 +113,32 @@ const action = redirect || undefined; // only set action when you want non-JS re
 			// Native HTML5 validation (no novalidate)
 			if (!form.checkValidity()) {
 				// small visual hint for invalid fields
-				form.querySelectorAll(":invalid").forEach((el) => {
-					el.classList.add("is-error");
-					el.setAttribute("aria-invalid", "true");
+				form.querySelectorAll(':invalid').forEach((el) => {
+					el.classList.add('is-error');
+					el.setAttribute('aria-invalid', 'true');
 				});
 				form.reportValidity();
 				return;
 			}
-			form.querySelectorAll(".is-error").forEach((el) => {
-				el.classList.remove("is-error");
-				el.removeAttribute("aria-invalid");
+			form.querySelectorAll('.is-error').forEach((el) => {
+				el.classList.remove('is-error');
+				el.removeAttribute('aria-invalid');
 			});
 
 			setBusy(true);
-			statusEl.textContent = "Sending…";
+			statusEl.textContent = 'Sending…';
 
 			const formData = new FormData(form);
-			if (!formData.get("form-name")) {
-				formData.set("form-name", form.getAttribute("name") || "contact");
+			if (!formData.get('form-name')) {
+				formData.set('form-name', form.getAttribute('name') || 'contact');
 			}
 
 			// Respect any explicit action=...; otherwise, post to "/"
-			const endpoint = form.getAttribute("action") || "/";
+			const endpoint = form.getAttribute('action') || '/';
 
 			const res = await fetch(endpoint, {
-				method: "POST",
-				headers: { "Content-Type": "application/x-www-form-urlencoded" },
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 				body: encodeFormData(formData),
 			});
 

--- a/src/components/organisms/SiteFooter.astro
+++ b/src/components/organisms/SiteFooter.astro
@@ -1,54 +1,60 @@
 ---
-/*
-==============================================================================
+/* ==============================================================================
   SiteFooter.astro — starter footer (CTA + links + legal)
-  - Token-driven colours/spacing; dark by default
-  - CTA block, three link columns (editable), legal row
-  - Cookie prefs hook (window.showCookiePreferences from CookieConsent)
-  - Back-to-top link
-  - Props (all optional; good defaults for a starter):
-      - cta?: { heading?: string; buttonText?: string; buttonHref?: string }
-      - groups?: Array<{ title: string; items: Array<{ label: string; href: string }> }>
-      - email?: string
 ============================================================================== */
 const ENV = import.meta.env;
 const SITE_NAME = ENV.PUBLIC_SITE_NAME ?? 'Site';
 const YEAR = new Date().getFullYear();
 
-const {
-	cta = {
-		heading: 'It all starts with a conversation.',
-		buttonText: 'Book a consultation.',
-		buttonHref: '/contact',
+type LinkItem = { label: string; href: string };
+type LinkGroup = { title: string; items: LinkItem[] };
+type CTA = { heading?: string; buttonText?: string; buttonHref?: string };
+
+interface Props {
+	cta?: CTA;
+	groups?: LinkGroup[];
+	email?: string;
+}
+
+// Pull props once, then build typed defaults
+const props = Astro.props as Props;
+
+const email = props.email ?? 'info@leesanter.co.uk';
+
+const cta: CTA = props.cta ?? {
+	heading: 'It all starts with a conversation.',
+	buttonText: 'Book a consultation.',
+	buttonHref: '/contact',
+};
+
+const defaultGroups: LinkGroup[] = [
+	{
+		title: 'New Projects',
+		items: [
+			{ label: 'Contact', href: '/contact' },
+			{ label: 'Book a consultation', href: '/contact' },
+			{ label: email, href: `mailto:${email}` },
+		],
 	},
-	groups = [
-		{
-			title: 'New Projects',
-			items: [
-				{ label: 'Contact', href: '/contact' },
-				{ label: 'Book a consultation', href: '/contact' },
-				{ label: 'info@leesanter.co.uk', href: 'mailto:info@leesanter.co.uk' },
-			],
-		},
-		{
-			title: 'Navigation',
-			items: [
-				{ label: 'Home', href: '/' },
-				{ label: 'Expertise', href: '/services' },
-				{ label: 'Case Studies', href: '/portfolio' },
-			],
-		},
-		{
-			title: 'Information',
-			items: [
-				{ label: 'FAQs', href: '/faqs' },
-				{ label: 'About', href: '/about' },
-				{ label: 'Insights', href: '/blog' },
-			],
-		},
-	],
-	email = 'info@leesanter.co.uk',
-} = Astro.props;
+	{
+		title: 'Navigation',
+		items: [
+			{ label: 'Home', href: '/' },
+			{ label: 'Expertise', href: '/services' },
+			{ label: 'Work', href: '/work' }, // was /portfolio
+		],
+	},
+	{
+		title: 'Information',
+		items: [
+			{ label: 'FAQs', href: '/faqs' },
+			{ label: 'About', href: '/about' },
+			{ label: 'Insights', href: '/insights' }, // was /blog
+		],
+	},
+];
+
+const groups: LinkGroup[] = props.groups ?? defaultGroups;
 ---
 
 <footer class="site-footer section--fill" data-footer data-scheme="dark">

--- a/src/components/organisms/SiteHeader.astro
+++ b/src/components/organisms/SiteHeader.astro
@@ -1,61 +1,67 @@
 ---
 /* ======================================================================
    SiteHeader.astro — sticky header with dropdowns + mobile menu
-
-   - Desktop: hover dropdowns; Mobile: disclosure buttons (parent link stays clickable)
-   - Sticky, hides on scroll down / shows on scroll up (hooked to ScrollListener body classes)
-   - Starts transparent; adds .has-bg once page is scrolled a bit
-   - CTA button (optional) sits to the right of the nav
-   - Uses your tokens and utilities (.container, .btn, spacing, colours)
 ====================================================================== */
 import LogoRaw from '../../assets/brand/wordmark.svg?raw';
 
 const ENV = import.meta.env;
 const SITE_NAME = ENV.PUBLIC_SITE_NAME ?? 'Site';
 
-const { pathname } = Astro.url;
-const currentPath = pathname.replace(/\/$/, '');
+/** Types */
+type NavChild = { label: string; href: string; isActive?: boolean };
+type NavItem = {
+	label: string;
+	href: string;
+	children?: NavChild[];
+	isActive?: boolean;
+	isActiveParent?: boolean;
+};
+type CTA = { label: string; href: string };
 
-/** Props (all optional)
- * - logoHref?: string (default "/")
- * - logoAlt?: string (default SITE_NAME)
- * - logoSvg?: string (path to an SVG in /public or an imported asset)
- * - nav?: Array<{ label: string, href: string, children?: {label:string, href:string}[] }>
- * - cta?: { label: string, href: string }  (omit to hide)
- * - transparent?: boolean (default true)
- */
-const {
-	logoHref = '/',
-	logoAlt = SITE_NAME,
-	nav = [
-		{
-			label: 'Services',
-			href: '/services',
-			children: [
-				{ label: 'Web Design', href: '/services/website-design' },
-				{ label: 'eCommerce', href: '/services/ecommerce-website-development-design' },
-				{ label: 'Web Apps', href: '/services/web-app-development' },
-			],
-		},
-		{ label: 'About', href: '/about' },
-		{ label: 'Portfolio', href: '/portfolio' },
-		{ label: 'Contact', href: '/contact' },
-	],
-	cta,
-	transparent = true,
-} = Astro.props;
-
-// Compute active states
-function normalize(href: string) {
-	return href.replace(/\/$/, '');
+interface Props {
+	logoHref?: string;
+	logoAlt?: string;
+	nav?: NavItem[];
+	cta?: CTA; // omit to hide CTA; we’ll render a sensible default if not provided
+	transparent?: boolean;
 }
-const navWithState = nav.map((item) => {
+
+/** Props + defaults */
+const props = Astro.props as Props;
+
+const logoHref = props.logoHref ?? '/';
+const logoAlt = props.logoAlt ?? SITE_NAME;
+const transparent = props.transparent ?? true;
+
+const defaultNav: NavItem[] = [
+	{
+		label: 'Services',
+		href: '/services',
+		children: [
+			{ label: 'Web Design', href: '/services/website-design' },
+			{ label: 'eCommerce', href: '/services/ecommerce-website-development-design' },
+			{ label: 'Web Apps', href: '/services/web-app-development' },
+		],
+	},
+	{ label: 'About', href: '/about' },
+	{ label: 'Work', href: '/work' }, // was “Portfolio”
+	{ label: 'Contact', href: '/contact' },
+];
+
+const nav: NavItem[] = props.nav ?? defaultNav;
+const ctaBtn: CTA | null = props.cta ?? { label: 'Get a quote', href: '/contact' };
+
+/** Active route state */
+const currentPath = Astro.url.pathname.replace(/\/$/, '');
+const normalize = (href: string) => href.replace(/\/$/, '');
+
+const navWithState: NavItem[] = nav.map((item) => {
 	const isActive = normalize(item.href) === currentPath;
-	const children = item.children?.map((c) => ({
+	const children: NavChild[] = (item.children ?? []).map((c) => ({
 		...c,
 		isActive: normalize(c.href) === currentPath,
 	}));
-	const isActiveParent = Boolean(children?.some((c) => c.isActive));
+	const isActiveParent = children.some((c) => c.isActive);
 	return { ...item, isActive, isActiveParent, children };
 });
 ---
@@ -63,8 +69,8 @@ const navWithState = nav.map((item) => {
 <header data-header class={`site-header${transparent ? ' is-transparent' : ''}`} role="banner">
 	<div class="site-header__inner container container--large">
 		<!-- Branding -->
-		<a href={logoHref} class="site-header__brand" aria-label="Lee Santer — Home">
-			<span class="sr-only">Lee Santer</span>
+		<a href={logoHref} class="site-header__brand" aria-label={`${logoAlt} — Home`}>
+			<span class="sr-only">{logoAlt}</span>
 			<span class="logo" aria-hidden="true" set:html={LogoRaw} />
 		</a>
 
@@ -96,7 +102,6 @@ const navWithState = nav.map((item) => {
 							]
 								.filter(Boolean)
 								.join(' ');
-							const id = `menu-item-${i}`;
 							const subId = `submenu-${i}`;
 							return (
 								<li class={itemClass}>
@@ -164,9 +169,15 @@ const navWithState = nav.map((item) => {
 						})
 					}
 
-					<li class="menu__item menu__cta">
-						<a href="/contact" class="btn btn--sm">Get a quote</a>
-					</li>
+					{
+						ctaBtn && (
+							<li class="menu__item menu__cta">
+								<a href={ctaBtn.href} class="btn btn--sm">
+									{ctaBtn.label}
+								</a>
+							</li>
+						)
+					}
 				</ul>
 			</div>
 		</nav>

--- a/src/components/organisms/WorkListing.astro
+++ b/src/components/organisms/WorkListing.astro
@@ -1,80 +1,169 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import WorkCard from '../../components/molecules/WorkCard.astro';
-import { mapDisplayServicesToLinks } from '../../lib/caseStudies';
+import { getAllWork, mapServiceKeysToLinks } from '../../lib/content';
+import { CATEGORIES, toSlug } from '../../lib/categories';
 
-const CATS = ['strategy', 'design', 'development', 'growth'] as const;
-type Cat = (typeof CATS)[number];
-type AllOrCat = Cat | 'all';
+type Category = (typeof CATEGORIES)[number];
+type CatSlug = 'strategy' | 'design' | 'development' | 'growth';
+type AllOrCatSlug = 'all' | CatSlug;
 
 interface Props {
-	entries: CollectionEntry<'case-studies'>[]; // already filtered/sorted by the page
-	active?: AllOrCat; // 'all' | 'strategy' | 'design' | 'development' | 'growth'
-	lede?: string; // optional line above filters
-}
-const { entries, active = 'all', lede = 'Filter by focus area.' } = Astro.props;
+	/** Controlled mode: pre-fetched entries (already filtered/sorted by the page) */
+	entries?: CollectionEntry<'work'>[];
 
-const pathFor = (cat: AllOrCat) => (cat === 'all' ? '/work#projects' : `/work/${cat}#projects`);
-const label = (s: string) => s.slice(0, 1).toUpperCase() + s.slice(1);
+	/** Autonomous mode options (ignored if entries passed) */
+	category?: Category | 'all';
+	includeSlugs?: string[];
+	excludeSlugs?: string[];
+	limit?: number;
+	shuffle?: boolean;
+
+	/** UI options */
+	showFilter?: boolean;
+	active?: AllOrCatSlug; // highlights the chip; useful on /work and /work/[category]
+	lede?: string;
+	id?: string; // anchor id; defaults to "projects"
+}
+
+/** Defaults */
+const {
+	entries: injected = undefined,
+	category = 'all',
+	includeSlugs = [],
+	excludeSlugs = [],
+	limit,
+	shuffle = false,
+	showFilter = false,
+	active,
+	lede = '',
+	id = 'projects',
+} = Astro.props as Props;
+
+/** Build data list (prefer injected entries; else fetch + filter) */
+let list: CollectionEntry<'work'>[] = [];
+
+if (injected?.length) {
+	list = injected;
+} else {
+	const all = await getAllWork(); // sorted newest → oldest in your helper
+	// explicit include wins
+	if (includeSlugs.length) {
+		list = all.filter((e) => includeSlugs.includes(e.slug));
+	} else {
+		list = [...all];
+		if (category !== 'all') {
+			list = list.filter((w) => w.data.serviceCategory === category);
+		}
+		if (excludeSlugs.length) {
+			list = list.filter((e) => !excludeSlugs.includes(e.slug));
+		}
+	}
+	if (shuffle) {
+		list = list.sort(() => Math.random() - 0.5);
+	}
+	if (typeof limit === 'number') {
+		list = list.slice(0, Math.max(0, limit));
+	}
+}
+
+/** Card view models (WorkCard expects denormalised props) */
+const cards = await Promise.all(
+	list.map(async (entry) => ({
+		href: `/work/${entry.slug}`,
+		title: entry.data.title,
+		summary: entry.data.summary,
+		img: entry.data.featuredImage,
+		alt: entry.data.featuredAlt,
+		chips: await mapServiceKeysToLinks(entry.data.services),
+	}))
+);
+
+/** Filter chips */
+const activeSlug: AllOrCatSlug =
+	active ?? (category === 'all' ? 'all' : (toSlug(category as Category) as CatSlug));
+
+const pathFor = (slug: AllOrCatSlug) =>
+	slug === 'all' ? '/work#projects' : `/work/${slug}#projects`;
+
+const proper = (s: string) => s.slice(0, 1).toUpperCase() + s.slice(1);
 ---
 
-<section class="section" id="projects">
+<section class="section" id={id}>
 	<div class="container container--large">
 		<div class="stack">
-			<div class="stack tiny">
-				{lede && <p>{lede}</p>}
+			{
+				(lede || showFilter) && (
+					<div class="stack tiny">
+						{lede && <p>{lede}</p>}
 
-				<nav aria-label="Filter projects by category">
-					<ul class="filter-chips" role="list">
-						{
-							(['all', ...CATS] as const).map((cat) => (
-								<li>
-									<a
-										href={pathFor(cat as AllOrCat)}
-										aria-current={cat === active ? 'page' : undefined}
-										class={`btn btn--sm btn--outline ${cat === active ? 'btn--active' : ''}`}
-									>
-										{label(cat as string)}
-									</a>
-								</li>
-							))
-						}
+						{showFilter && (
+							<nav aria-label="Filter projects by category">
+								<ul class="filter-chips" role="list">
+									{(
+										[
+											'all',
+											...CATEGORIES.map((c) => toSlug(c) as CatSlug),
+										] as AllOrCatSlug[]
+									).map((slug) => (
+										<li>
+											<a
+												href={pathFor(slug)}
+												aria-current={
+													slug === activeSlug ? 'page' : undefined
+												}
+												class={`btn btn--sm btn--outline ${slug === activeSlug ? 'btn--active' : ''}`}
+											>
+												{proper(slug)}
+											</a>
+										</li>
+									))}
+								</ul>
+							</nav>
+						)}
+					</div>
+				)
+			}
+
+			{
+				cards.length === 0 ? (
+					<p class="muted">No projects yet.</p>
+				) : (
+					<ul class="work-grid" role="list">
+						{cards.map((c) => (
+							<li>
+								<WorkCard {...c} />
+							</li>
+						))}
 					</ul>
-				</nav>
-			</div>
-
-			<ul class="work-grid" role="list">
-				{
-					entries.map((entry) => (
-						<li>
-							<WorkCard
-								entry={entry}
-								services={mapDisplayServicesToLinks(entry.data.displayServices)}
-							/>
-						</li>
-					))
-				}
-			</ul>
+				)
+			}
 		</div>
 	</div>
 </section>
 
 <style lang="scss">
+	/* Anchor offset for sticky header */
 	#projects {
 		scroll-margin-top: calc(var(--header-height, 56px) + var(--size--medium));
 	}
 
 	.work-grid {
-		flex-direction: column;
-		grid-template-rows: auto auto;
-		grid-auto-columns: 1fr;
-		justify-content: flex-start;
-		width: 100%;
-		display: flex;
+		display: grid;
 		gap: var(--size--large);
-
 		list-style: none;
-
 		padding: 0;
+	}
+
+	/* simple responsive grid; tweak to your taste */
+	@media (min-width: 720px) {
+		.work-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+	@media (min-width: 1100px) {
+		.work-grid {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
 	}
 </style>

--- a/src/components/utils/CookieConsent.astro
+++ b/src/components/utils/CookieConsent.astro
@@ -103,7 +103,7 @@ const STORAGE_KEY = `cookie-consent.v${CONSENT_VERSION}`;
 	}
 </style>
 
-<script type="module">
+<script is:inline type="module">
 	(() => {
 		const banner = document.getElementById('cookie-consent');
 		if (!banner) return;

--- a/src/components/utils/Img.astro
+++ b/src/components/utils/Img.astro
@@ -13,38 +13,53 @@
  *  - priority?: boolean       (hero/LCP: eager, sync decode, fetchpriority=high)
  *  - ...any other <img> attributes (style, loading, decoding, etc.)
  */
-import { Image } from "astro:assets";
+import { Image, Picture } from 'astro:assets';
+import type { ImageMetadata, ImageOutputFormat } from 'astro';
 
-export interface Props {
-	src: any; // local import OR remote URL string
+interface Props {
+	src: ImageMetadata;
 	alt: string;
 	widths?: number[];
 	sizes?: string;
-	format?: Array<"avif" | "webp" | "png" | "jpeg">;
-	loading?: "lazy" | "eager";
-	decoding?: "async" | "auto" | "sync";
-	class?: string;
+	format?: ImageOutputFormat | ImageOutputFormat[]; // accept both
+	loading?: 'lazy' | 'eager';
+	decoding?: 'async' | 'sync' | 'auto';
+	className?: string;
 }
-
 const {
 	src,
 	alt,
 	widths = [480, 768, 1024, 1440],
-	sizes = "100vw",
-	format = ["avif", "webp", "jpeg"],
-	loading = "lazy",
-	decoding = "async",
-	class: className = "",
-} = Astro.props;
-
-const isRemote = typeof src === "string";
-const isSvg = (typeof src === "string" && src.endsWith(".svg")) || (src?.src && src.src.endsWith?.(".svg"));
+	sizes = '100vw',
+	format,
+	loading = 'lazy',
+	decoding = 'async',
+	className,
+} = Astro.props as Props;
 ---
 
 {
-	isRemote || isSvg ? (
-		<img src={typeof src === "string" ? src : src.src} alt={alt} loading={loading} decoding={decoding} class={className} />
+	Array.isArray(format) ? (
+		<Picture
+			src={src}
+			alt={alt}
+			widths={widths}
+			sizes={sizes}
+			formats={format}
+			loading={loading}
+			decoding={decoding}
+			class={className}
+		/>
 	) : (
-		<Image src={src} alt={alt} widths={widths} sizes={sizes} format={format} loading={loading} decoding={decoding} class={className} />
+		<Image
+			src={src}
+			alt={alt}
+			widths={widths}
+			sizes={sizes}
+			format={format}
+			loading={loading}
+			decoding={decoding}
+			class={className}
+		/>
 	)
 }

--- a/src/components/utils/SEO.astro
+++ b/src/components/utils/SEO.astro
@@ -217,4 +217,4 @@ if (props.structuredData) {
 {ogImage && <meta name="twitter:image" content={ogImage} />}
 
 <!-- JSON-LD -->
-{ld.length > 0 && <script type="application/ld+json" set:html={JSON.stringify(ld)} />}
+{ld.length > 0 && <script is:inline type="application/ld+json" set:html={JSON.stringify(ld)} />}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -41,7 +41,7 @@ const work = defineCollection({
     siteUrl: z.string().url().optional(),
     completedDate: z.coerce.date(),
     featuredHome: z.boolean().default(false),
-    featureWeight: z.number().optional(),
+    featureWeight: z.number().int().min(0).max(100).default(999), // lower = higher priority
     sections: z.array(z.object({
       title: z.string(),
       body: z.string(),

--- a/src/layouts/Minimal.astro
+++ b/src/layouts/Minimal.astro
@@ -8,24 +8,24 @@
    - <main tabindex="-1"> for accessible focus targets
 ====================================================================== */
 
-import "../styles/main.scss";
-import SEO from "../components/utils/SEO.astro";
-import HeadAssets from "../components/utils/HeadAssets.astro";
-import FontAssets from "../components/utils/FontAssets.astro";
+import '../styles/main.scss';
+import SEO from '../components/utils/SEO.astro';
+import HeadAssets from '../components/utils/HeadAssets.astro';
+import FontAssets from '../components/utils/FontAssets.astro';
 
 const ENV = import.meta.env;
-const fontPreloads = (ENV.PUBLIC_FONT_PRELOADS || "")
-	.split(",")
+const fontPreloads = (ENV.PUBLIC_FONT_PRELOADS || '')
+	.split(',')
 	.map((s) => s.trim())
 	.filter(Boolean);
-const HTML_LANG = ENV.PUBLIC_HTML_LANG ?? "en-GB";
+const HTML_LANG = ENV.PUBLIC_HTML_LANG ?? 'en-GB';
 
 const {
 	title,
 	description,
 	canonical,
 	noindex = false,
-	pageClass = "",
+	pageClass = '',
 	structuredData,
 	ogImage,
 	type, // "website" | "article"
@@ -42,12 +42,12 @@ const {
 		<meta name="color-scheme" content="light" />
 
 		<SEO
-			{title}
-			{description}
-			{canonical}
-			{noindex}
-			{structuredData}
-			{ogImage}
+			title={title}
+			description={description}
+			canonical={canonical}
+			noindex={noindex}
+			structuredData={structuredData}
+			image={ogImage /* legacy var name, now forwarded as image */}
 			type={type}
 			publishedTime={publishedTime}
 			modifiedTime={modifiedTime}
@@ -59,7 +59,7 @@ const {
 	</head>
 	<body>
 		<div class="page-wrapper">
-			<main id="main" class:list={["main-wrapper", pageClass]} tabindex="-1">
+			<main id="main" class:list={['main-wrapper', pageClass]} tabindex="-1">
 				<slot />
 			</main>
 		</div>

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,8 +1,25 @@
-export const CATEGORIES = ['Strategy','Design','Development','Growth'] as const;
+// src/lib/categories.ts
+
+/** Proper-case categories used in content frontmatter */
+export const CATEGORIES = ['Strategy', 'Design', 'Development', 'Growth'] as const;
 export type Category = typeof CATEGORIES[number];
 
-export const toSlug = (c: Category) => c.toLowerCase();                 // "Design" -> "design"
-export const fromSlug = (s: string) =>
-  (s && (['strategy','design','development','growth'] as const).includes(s as any))
-    ? (s[0].toUpperCase() + s.slice(1)) as Category
-    : null;
+/** Slug forms used in routes */
+export const CATEGORY_SLUGS = ['strategy', 'design', 'development', 'growth'] as const;
+export type CatSlug = typeof CATEGORY_SLUGS[number];
+
+/** Proper → slug  ("Design" -> "design") */
+export function toSlug(category: Category): CatSlug {
+  return category.toLowerCase() as CatSlug;
+}
+
+/** slug → Proper  ("design" -> "Design") */
+export function fromSlug(slug: CatSlug): Category {
+  const i = CATEGORY_SLUGS.indexOf(slug);
+  return CATEGORIES[i];
+}
+
+/** Type guard for arbitrary strings (runtime safety, optional) */
+export function isCatSlug(x: string): x is CatSlug {
+  return (CATEGORY_SLUGS as readonly string[]).includes(x);
+}

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -43,21 +43,33 @@ export async function mapServiceKeysToLinks(keys: string[]) {
   });
 }
 
-export async function getAllWork(): Promise<Work[]> {
-  const entries = await getCollection('work', w => !w.data.draft);
-  return entries.sort(byDateDesc);
-}
+const byFeatureThenDate = (a: Work, b: Work) => {
+  const wa = a.data.featureWeight ?? 999;
+  const wb = b.data.featureWeight ?? 999;
+  if (wa !== wb) return wa - wb;     // lower weight first
+  return byDateDesc(a, b);           // tie-break by recency
+};
 
+export async function getAllWork(): Promise<Work[]> {
+  const all = await getCollection('work', (w) => !w.data.draft);
+  return all.sort(byDateDesc);
+}
 export async function getWorkForHome(limit = 4): Promise<Work[]> {
   const all = await getAllWork();
-  const featured = all.filter(w => w.data.featuredHome);
-  featured.sort((a, b) => {
-    const pa = a.data.featureWeight ?? 999;
-    const pb = b.data.featureWeight ?? 999;
-    return pa !== pb ? pa - pb : byDateDesc(a, b);
-  });
-  return featured.slice(0, limit);
+  const featured = all.filter((w) => w.data.featuredHome).sort(byFeatureThenDate);
+
+  const picked: Work[] = featured.slice(0, limit);
+
+  if (picked.length < limit) {
+    for (const w of all) {
+      if (picked.find((p) => p.slug === w.slug)) continue;
+      picked.push(w);
+      if (picked.length >= limit) break;
+    }
+  }
+  return picked.slice(0, limit);
 }
+
 
 export function nextPrev<T extends { slug: string }>(items: T[], currentSlug: string) {
   const list = [...items];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,32 +1,14 @@
 ---
 import Base from '../layouts/Base.astro';
-import {
-	getWorkForHome,
-	getAllPosts,
-	mapServiceKeysToLinks,
-	getAllWorkTestimonials,
-} from '../lib/content';
+import WorkListing from 'src/components/organisms/WorkListing.astro';
+
+import { getWorkForHome, getAllPosts, getAllWorkTestimonials } from '../lib/content';
 
 export const prerender = true;
 
-// Featured Work (limit 4; ordered by featureWeight then completedDate)
-const featuredWork = await getWorkForHome(4);
-
-// Pre-resolve service chips for each card (do async work in front-matter)
-const workCards = await Promise.all(
-	featuredWork.map(async (w) => ({
-		slug: w.slug,
-		title: w.data.title,
-		summary: w.data.summary,
-		img: w.data.featuredImage,
-		alt: w.data.featuredAlt,
-		services: await mapServiceKeysToLinks(w.data.services),
-	}))
-);
-
 // Latest Insights (grab a few; index page still handles pagination)
 const latestInsights = (await getAllPosts()).slice(0, 3);
-
+const homeEntries = await getWorkForHome(4);
 const testimonials = await getAllWorkTestimonials();
 ---
 
@@ -49,40 +31,7 @@ const testimonials = await getAllWorkTestimonials();
 	<section class="section" aria-labelledby="home-work">
 		<div class="container container--large">
 			<h2 id="home-work">Featured work</h2>
-
-			{
-				workCards.length === 0 ? (
-					<p>
-						Flag up to four case studies with <code>featuredHome: true</code> to
-						populate this section.
-					</p>
-				) : (
-					<ul class="work-grid">
-						{workCards.map((card) => (
-							<li class="work-card">
-								<a href={`/work/${card.slug}`}>
-									<img src={card.img.src} alt={card.alt} loading="lazy" />
-									<h3>{card.title}</h3>
-									<p>{card.summary}</p>
-								</a>
-
-								{card.services.length > 0 && (
-									<p class="chips">
-										{card.services.map((s) =>
-											s.href ? (
-												<a href={s.href}>{s.label}</a>
-											) : (
-												<span>{s.label}</span>
-											)
-										)}
-									</p>
-								)}
-							</li>
-						))}
-					</ul>
-				)
-			}
-
+			<WorkListing entries={homeEntries} lede="Selected work." />
 			<p class="see-all"><a href="/work">See all work →</a></p>
 		</div>
 	</section>

--- a/src/pages/insights/[...page].astro
+++ b/src/pages/insights/[...page].astro
@@ -1,20 +1,29 @@
 ---
 import Base from '../../layouts/Base.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 import { POSTS_PER_PAGE } from '../../lib/constants';
 import InsightCard from '../../components/molecules/InsightCard.astro';
 
-export async function getStaticPaths({ paginate }) {
+// Prefer a typed signature so paginate is known
+import type { GetStaticPaths } from 'astro';
+
+export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 	const posts = await getCollection('insights', (p) => !p.data.draft);
 	posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 	return paginate(posts, { pageSize: POSTS_PER_PAGE }); // /insights, /insights/2, ...
-}
+};
 
-const { page } = Astro.props;
+// Type the page prop shape Astro passes to paginated routes
+type PageProp = {
+	data: CollectionEntry<'insights'>[];
+	url: { prev?: string; next?: string };
+};
+
+const { page } = Astro.props as { page: PageProp };
 ---
 
 <Base title="Insights" seoTitleTemplate="%s | Insights" description="Latest articles and notes.">
-	<!-- ✅ Inject prev/next + RSS into <head> via Base's head slot -->
+	<!-- head slot: prev/next + RSS -->
 	<Fragment slot="head">
 		{page.url.prev && <link rel="prev" href={page.url.prev} />}
 		{page.url.next && <link rel="next" href={page.url.next} />}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,8 +3,9 @@
 // ----------------------------------------------------------------------
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
 
-export async function GET(context) {
+export async function GET(context: APIContext) {
   const site = (import.meta.env.PUBLIC_SITE_URL as string) ?? context.site?.toString();
   const posts = await getCollection('insights', (p) => !p.data.draft);
   posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());

--- a/src/pages/work/[category].astro
+++ b/src/pages/work/[category].astro
@@ -1,49 +1,17 @@
 ---
 import Base from '../../layouts/Base.astro';
-import WorkFilter from '../../components/molecules/WorkFilter.astro';
-import WorkCard from '../../components/molecules/WorkCard.astro';
-import { getAllWork, mapServiceKeysToLinks } from '../../lib/content';
-import { fromSlug, toSlug } from '../../lib/categories';
+import WorkListing from '../../components/organisms/WorkListing.astro';
+import { fromSlug, CATEGORY_SLUGS, type CatSlug } from '../../lib/categories';
 
 export async function getStaticPaths() {
-	return ['strategy', 'design', 'development', 'growth'].map((c) => ({
-		params: { category: c },
-	}));
+	return CATEGORY_SLUGS.map((slug) => ({ params: { category: slug } }));
 }
 
-const slug = Astro.params.category!;
-const category = fromSlug(slug)!; // one of 'Strategy' | 'Design' | 'Development' | 'Growth'
-
-const all = await getAllWork();
-const filtered = all.filter((w) => w.data.serviceCategory === category);
-
-const cards = await Promise.all(
-	filtered.map(async (w) => ({
-		href: `/work/${w.slug}`,
-		title: w.data.title,
-		summary: w.data.summary,
-		img: w.data.featuredImage,
-		alt: w.data.featuredAlt,
-		chips: await mapServiceKeysToLinks(w.data.services),
-	}))
-);
+const { category } = Astro.params as { category: CatSlug };
+const proper = fromSlug(category); // "Design" | "Strategy" | ...
 ---
 
 <Base title={`Work — ${category}`} description={`Projects in ${category}.`}>
 	<h1>Work — {category}</h1>
-	<WorkFilter active={slug} />
-
-	{
-		cards.length === 0 ? (
-			<p>No projects in {category} yet.</p>
-		) : (
-			<ul class="work-grid">
-				{cards.map((c) => (
-					<li>
-						<WorkCard {...c} />
-					</li>
-				))}
-			</ul>
-		)
-	}
+	<WorkListing category={proper} showFilter active={category} lede={`Projects in ${proper}.`} />
 </Base>

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -1,33 +1,12 @@
 ---
 import Base from '../../layouts/Base.astro';
-import WorkFilter from '../../components/molecules/WorkFilter.astro';
-import WorkCard from '../../components/molecules/WorkCard.astro';
-import { getAllWork, mapServiceKeysToLinks } from '../../lib/content';
+import WorkListing from '../../components/organisms/WorkListing.astro';
+import { getAllWork } from '../../lib/content';
 
-const all = await getAllWork();
-const cards = await Promise.all(
-	all.map(async (w) => ({
-		href: `/work/${w.slug}`,
-		title: w.data.title,
-		summary: w.data.summary,
-		img: w.data.featuredImage,
-		alt: w.data.featuredAlt,
-		chips: await mapServiceKeysToLinks(w.data.services),
-	}))
-);
+const entries = await getAllWork(); // already sorted newest→oldest
 ---
 
-<Base title="Work" description="Selected projects.">
+<Base title="Work" seoTitleTemplate="%s | Work" description="Selected projects.">
 	<h1>Work</h1>
-	<WorkFilter active={null} />
-
-	<ul class="work-grid">
-		{
-			cards.map((c) => (
-				<li>
-					<WorkCard {...c} />
-				</li>
-			))
-		}
-	</ul>
+	<WorkListing entries={entries} showFilter active="all" lede="Filter by focus area." />
 </Base>


### PR DESCRIPTION
… + SEO polish

feat: flexible WorkListing + typed header/footer + insights paginator + SEO polish

- components:
  - add WorkListing organism with autonomous/controlled API (category, limit, includeSlugs/excludeSlugs, showFilter, active, lede, id)
  - type WorkCard props; chips now strongly typed (label, href|null)
  - type SiteHeader + SiteFooter; remove implicit-any warnings, wire cta/email usage
  - Img.astro: support multiple formats via <Picture> formats=[], else <Image> format=string
- pages:
  - /work: use <WorkListing> with chips; clean leftovers
  - /work/[category]: typed route param (CatSlug), pass proper Category + active chip
  - /insights/[...page]: typed paginator (page.url/page.data), add <link rel="prev/next"> + RSS link
  - /insights/rss.xml.ts: RSS feed with @astrojs/rss
- content/helpers:
  - categories.ts: export CATEGORIES, CATEGORY_SLUGS, toSlug(), fromSlug(), isCatSlug()
  - content.ts: helpers for work cards remain; (home selection available via getWorkForHome if needed)
- seo:
  - SEO.astro: prefer site settings over env; add is:inline to JSON-LD script
  - Breadcrumb JSON-LD for Work/Insights singles (wired via Base structuredData in their pages)
- layouts:
  - Minimal.astro: forward image prop correctly (ogImage -> image)
- misc:
  - ContactForm/CookieConsent: mark scripts is:inline (silence processing hint)
  - fix all astro check errors (implicit any / wrong prop names / unused imports)

Co-authored-by: Your Future Self
