### PR TITLE
Feat/section pageintro media grid

### DIFF
--- a/src/components/atoms/Section.astro
+++ b/src/components/atoms/Section.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Section — minimal structural wrapper
+ * - Renders <section> (default) or <div>
+ * - Optional inner container: 'small' | 'medium' | 'large' | false
+ * - Optional scheme override via data-scheme
+ *
+ * Usage:
+ *  <Section scheme="dark" container="large">
+ *    ...content...
+ *  </Section>
+ */
+
+interface Props {
+	id?: string;
+	class?: string;
+	/** Element to render as */
+	as?: 'section' | 'div';
+	/** Container size or false for none (defaults to 'large') */
+	container?: 'small' | 'medium' | 'large' | false;
+	/** Force colour scheme for this block */
+	scheme?: 'light' | 'dark' | 'inherit';
+}
+
+const {
+	id,
+	class: className = '',
+	as = 'section',
+	container = 'large',
+	scheme = 'inherit',
+} = Astro.props as Props;
+
+const containerClass =
+	container === false
+		? ''
+		: container === 'small'
+			? 'container container--small'
+			: container === 'large'
+				? 'container container--large'
+				: 'container'; // 'medium'
+---
+
+{
+	as === 'div' ? (
+		<div
+			id={id}
+			class:list={['section', className]}
+			data-scheme={scheme !== 'inherit' ? scheme : undefined}
+		>
+			{container === false ? (
+				<slot />
+			) : (
+				<div class={containerClass}>
+					<slot />
+				</div>
+			)}
+		</div>
+	) : (
+		<section
+			id={id}
+			class:list={['section', className]}
+			data-scheme={scheme !== 'inherit' ? scheme : undefined}
+		>
+			{container === false ? (
+				<slot />
+			) : (
+				<div class={containerClass}>
+					<slot />
+				</div>
+			)}
+		</section>
+	)
+}

--- a/src/components/molecules/PageIntro.astro
+++ b/src/components/molecules/PageIntro.astro
@@ -1,0 +1,95 @@
+---
+/**
+ * PageIntro — headline block that delegates structure to <Section>
+ * - Props:
+ *   • title: string
+ *   • eyebrow?: string
+ *   • lede?: string
+ *   • align?: 'left' | 'center' (default 'left')
+ *   • as?: 'section' | 'div' (default 'section')
+ *   • container?: 'small' | 'medium' | 'large' | false (default 'large')
+ *   • scheme?: 'light' | 'dark' | 'inherit' (default 'inherit')
+ *   • id?: string
+ *   • class?: string
+ * - Slots:
+ *   • default (renders under the lede)
+ *   • <slot name="actions" /> for buttons/links row
+ */
+
+import Section from '../atoms/Section.astro';
+
+interface Props {
+	title: string;
+	eyebrow?: string;
+	lede?: string;
+	align?: 'left' | 'center';
+	as?: 'section' | 'div';
+	container?: 'small' | 'medium' | 'large' | false;
+	scheme?: 'light' | 'dark' | 'inherit';
+	id?: string;
+	class?: string;
+}
+
+const {
+	title,
+	eyebrow,
+	lede,
+	align = 'left',
+	as = 'section',
+	container = 'large',
+	scheme = 'inherit',
+	id,
+	class: className = '',
+} = Astro.props as Props;
+---
+
+<Section
+	as={as}
+	id={id}
+	class={`page-intro ${align === 'center' ? 'is-center' : ''} ${className}`.trim()}
+	container={container}
+	scheme={scheme}
+>
+	<div class="stack small">
+		{eyebrow && <p class="eyebrow">{eyebrow}</p>}
+		<h1 class="h1">{title}</h1>
+		{lede && <p class="lede text-large">{lede}</p>}
+
+		<!-- Optional actions row -->
+		<div class="actions"><slot name="actions" /></div>
+
+		<!-- Optional extra content below -->
+		<slot />
+	</div>
+</Section>
+
+<style lang="scss">
+	.page-intro {
+		/* spacing handled by .section + container; keep text styles minimal */
+	}
+	.page-intro.is-center {
+		text-align: center;
+	}
+	.page-intro .eyebrow {
+		font-size: var(--font--small);
+		color: var(--text-muted-colour);
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+	.page-intro .lede {
+		color: var(--text-colour);
+		max-width: 60ch;
+		margin-inline: 0; /* centered via parent when is-center */
+	}
+	.page-intro.is-center .lede {
+		margin-inline: auto;
+	}
+	.page-intro .actions:empty {
+		display: none;
+	}
+	.page-intro .actions {
+		display: inline-flex;
+		gap: var(--size--small);
+		flex-wrap: wrap;
+	}
+</style>

--- a/src/components/organisms/MediaGrid.astro
+++ b/src/components/organisms/MediaGrid.astro
@@ -1,0 +1,85 @@
+---
+import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+
+type Item = { src: string | ImageMetadata; alt?: string };
+
+interface Props {
+	items: Item[];
+	columns?: 2 | 3 | 4;
+	gap?: 'small' | 'medium' | 'large';
+}
+
+const { items, columns = 3, gap = 'large' } = Astro.props as Props;
+
+function isMeta(x: any): x is ImageMetadata {
+	return x && typeof x === 'object' && 'src' in x && 'width' in x && 'height' in x;
+}
+---
+
+<div class="media-grid" data-cols={columns} data-gap={gap}>
+	{
+		items.map((it) => (
+			<figure class="media-grid__item">
+				{isMeta(it.src) ? (
+					<Image
+						src={it.src}
+						alt={it.alt ?? ''}
+						widths={[640, 960, 1440]}
+						sizes="(min-width:1100px) 33vw, 50vw"
+						loading="lazy"
+						decoding="async"
+					/>
+				) : (
+					<img
+						src={it.src as string}
+						alt={it.alt ?? ''}
+						loading="lazy"
+						decoding="async"
+					/>
+				)}
+			</figure>
+		))
+	}
+</div>
+
+<style lang="scss">
+	.media-grid {
+		display: grid;
+		gap: var(--size--large);
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+	.media-grid[data-cols='2'] {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+	.media-grid[data-cols='4'] {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+
+	.media-grid[data-gap='small'] {
+		gap: var(--size--small);
+	}
+	.media-grid[data-gap='medium'] {
+		gap: var(--size--medium);
+	}
+	.media-grid[data-gap='large'] {
+		gap: var(--size--large);
+	}
+
+	.media-grid__item :where(img, picture) {
+		display: block;
+		width: 100%;
+		height: auto;
+	}
+
+	@media (max-width: 1100px) {
+		.media-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+	@media (max-width: 700px) {
+		.media-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>


### PR DESCRIPTION
- Adds <Section> atom with container sizing and per-block scheme overrides.
- Refactors <PageIntro> to use <Section>, keeping API (title/lede/eyebrow) and adding align/scheme/container passthrough.
- (Optional) Adds <MediaGrid> organism for simple responsive media blocks.

Why:
- DRY structural markup across pages.
- Single source of truth for section spacing and light/dark overrides.
- Cleaner intros that match the rest of the layout system.

Notes:
- No breaking changes expected; where PageIntro previously wrapped its own section/container, it now defers to <Section>.
- You can pass scheme="dark" or container="small|medium|large|false" directly on PageIntro.
